### PR TITLE
Increased(lowered) year range to 1999 in asklib statistics page.

### DIFF
--- a/src/Statistics/StatisticsBase.php
+++ b/src/Statistics/StatisticsBase.php
@@ -36,7 +36,7 @@ abstract class StatisticsBase extends KifiStatisticsBase {
       'year' => [
         '#type' => 'select',
         '#title' => $this->t('Year'),
-        '#options' => array_combine(range(date('Y'), 2000), range(date('Y'), 2000)),
+        '#options' => array_combine(range(date('Y'), 1999), range(date('Y'), 1999)),
         '#empty_option' => $this->t('- Any -'),
         '#default_value' => $this->getParameter('year'),
       ]


### PR DESCRIPTION
- Currently the minimum year is 2000, this crops some older answers from the asklib. Now lowered to 1999.
- Moved this to separate branch.