### PR TITLE
Removed unexisting interface used by `QuestionVariables`

### DIFF
--- a/src/EmailVariables/QuestionVariables.php
+++ b/src/EmailVariables/QuestionVariables.php
@@ -6,7 +6,6 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountProxy;
 use Drupal\asklib\UserMailGroupHelper;
-use Drupal\kifimail\VariablesProcessorInterface;
 /**
  * Extract variables from questions.
  *
@@ -15,7 +14,7 @@ use Drupal\kifimail\VariablesProcessorInterface;
  *   class = "Drupal\asklib\QuestionInterface"
  * )
  */
-class QuestionVariables implements VariablesProcessorInterface {
+class QuestionVariables {
   protected $user_storage;
   protected $mail_groups;
 


### PR DESCRIPTION
This fix nor the state before it does not affect that much the site operation. It was just that php was throwing errors in Drupal Console.

QuestionVariables was implementing unexisting `VariablesProcessorInterface` interface from `kifimail` module.
With newer php this is was causing errors for me, so I removed it. This should not have any functional impact
on the main site.