### PR TITLE
Add missing form mode for Question edit form

### DIFF
--- a/asklib.install
+++ b/asklib.install
@@ -2,6 +2,7 @@
 
 use Drupal\comment\CommentManagerInterface;
 use Drupal\comment\Plugin\Field\FieldType\CommentItemInterface;
+use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 
@@ -45,4 +46,22 @@ function asklib_update_8001() {
   
   \Drupal::entityDefinitionUpdateManager()
     ->installFieldStorageDefinition('ip_address', 'asklib_question', 'asklib', $storage_definition);
+}
+
+/**
+ * Add missing form mode configuration to asklib_question. This helps to bypass
+ * an error that happens during Drupal core update, from 8.7 to 8.8.
+ */
+function asklib_update_8002() {
+
+  // Check if we already have installed the configuration
+  $entity = \Drupal::entityTypeManager()->getStorage('entity_form_mode')->load('asklib_question.edit');
+  if(!$entity) {
+    // If not load and write the configuration to Drupal config.
+    $config_path = drupal_get_path('module', 'asklib') . '/config/install';
+    $source = new FileStorage($config_path);
+    $config_storage = \Drupal::service('config.storage');
+    $config_storage->write('core.entity_form_mode.asklib_question.edit', $source->read('core.entity_form_mode.asklib_question.edit'));
+  }
+
 }

--- a/config/install/core.entity_form_mode.asklib_question.edit.yml
+++ b/config/install/core.entity_form_mode.asklib_question.edit.yml
@@ -1,0 +1,10 @@
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - asklib
+id: asklib_question.edit
+label: 'Ask a Librarian Question'
+targetEntityType: asklib_question
+cache: true


### PR DESCRIPTION
I ran to an issue during core Drupal core update from 8.7 to 8.9. An error occurs when 'EntityDisplayBase->calculateDependencies()' tries to fetch matching form mode config for custom form view config for Question edit form.

The issue occurs (in our site) when any config form's display mode is anything else than 'default' and the configuration form is using 'entity reference autocomplete field'. The only form display configuration that currently matches both those conditions is Question edit form (form that is only shown to asklib administrators when they edit a question).

Commit message:
This helps bypass an update error in Drupal core:
https://www.drupal.org/project/drupal/issues/3062441