### PR TITLE
Add autocomplete attribute to email fields

### DIFF
--- a/asklib.module
+++ b/asklib.module
@@ -403,6 +403,7 @@ function asklib_form_comment_comment_asklib_form_alter(&$form, FormStateInterfac
   $form['actions']['submit']['#value'] = t('Send');
   $form['comment_body']['widget'][0]['#format'] = 'basic_html_without_ckeditor';
   $form['comment_body']['widget'][0]['#title'] = t('Your comment');
+  $form['field_email']['widget'][0]['value']['#attributes']['autocomplete'] = 'email';
 }
 
 function asklib_user_login($account) {

--- a/src/Form/QuestionForm.php
+++ b/src/Form/QuestionForm.php
@@ -33,6 +33,7 @@ class QuestionForm extends ContentEntityForm {
 
     $form['email']['widget'][0]['value']['#title'] = $this->t('Your email address');
     $form['email']['widget'][0]['value']['#required'] = TRUE;
+    $form['email']['widget'][0]['value']['#attributes']['autocomplete'] = 'email';
 
     $form['municipality']['widget']['#description'] = '';
     $form['municipality']['widget']['#title'] = $this->t('Your municipality');


### PR DESCRIPTION
Due to accessibility requirements, the autocomplete must be set "on" in
email field that is found in question form and question comment form.