### PR TITLE
Add the language code to remote question forms

### DIFF
--- a/src/Form/RemoteQuestionForm.php
+++ b/src/Form/RemoteQuestionForm.php
@@ -28,6 +28,12 @@ class RemoteQuestionForm extends ContentEntityForm {
       }
     }
 
+    // Need to set language manually because Question is not marked as 'translatable'.
+    $form['langcode'] = [
+      '#type' => 'value',
+      '#value' => \Drupal::languageManager()->getCurrentLanguage()->getId(),
+    ];
+
     $form['body']['widget'][0]['#format'] = 'basic_html_without_ckeditor';
     $form['body']['widget'][0]['#rows'] = 6;
     $form['body']['widget'][0]['#description'] = '';


### PR DESCRIPTION
This fixes the submitted questions from embedded asklib forms for having wrong language code saved into database.

It seems that the same fix was done in the regular question form(QuestionForm.php) in the past. This does not fix the issue of ekirjasto submitting to channel the questions, that's a separate issue:
https://gitlab.com/libraries-fi/ekirjasto/-/merge_requests/128